### PR TITLE
Improve mention parsing and async testing

### DIFF
--- a/backend/app/utils/mention_parser.py
+++ b/backend/app/utils/mention_parser.py
@@ -8,8 +8,11 @@ def parse_mention(content: str) -> str | None:
     - Can contain letters, numbers, and underscores
     - Cannot start with numbers or be empty after @
     """
-    # Match @ followed by letter, then letters/numbers/underscores
-    match = re.search(r"@([a-zA-Z][a-zA-Z0-9_]*)", content)
+    # Match @ followed by a valid name that is not part of another word (e.g. an email)
+    # The negative lookbehind ensures the @ is either at the start of the string
+    # or preceded by a non-word character so that strings like "email@domain.com"
+    # are ignored.
+    match = re.search(r"(?<!\w)@([a-zA-Z][a-zA-Z0-9_]*)", content)
     if match:
         return match.group(1)
     return None


### PR DESCRIPTION
## Summary
- refine mention parser so email addresses aren't mistaken for mentions
- add `async_client` fixture for async tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687a52d1d4508328a5efa66b75174e6e